### PR TITLE
Fix get in Single Table Design

### DIFF
--- a/src/table-builder/single-table-builder.ts
+++ b/src/table-builder/single-table-builder.ts
@@ -286,7 +286,6 @@ export class TablePartClient<
     }
     return (await this.tableClient.get(
       {
-        ...item,
         [this.tableClient.tableConfig.keyNames.partitionKey]: partition,
         [this.tableClient.tableConfig.keyNames.sortKey]: sort,
       },


### PR DESCRIPTION
This part is not necessary because we need only the primary key, partition and sort keys not additional columns.